### PR TITLE
Fixed broken links in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ https://wiki.duraspace.org/display/hydra/Hydra+Project+Intellectual+Property+Lic
 ## Submitting Changes
 
 * Push your changes to a topic branch in your fork of the repository.
-* Submit a pull request to the project https://github.com/hydra/hydra
+* Submit a pull request to the project https://github.com/projecthydra/hydra
 * Update your Github issue – if you use the hub command, this can be automated – by associating the issue with the pull request.
 
 # Additional Resources

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you need to previous hydra gem, you can use `gem ngauthier-hydra`.
 
 ## Developer Wiki
 
-https://github.com/hydra/hydra/wiki
+https://github.com/projecthydra/hydra/wiki
 
 ## Installation
 


### PR DESCRIPTION
changed from `github.com/hydra/hydra` to `github.com/projecthydra/hydra`
