### PR TITLE
Adding CONTRIBUTORS.md file for reference

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Mark Bussey <mark@curationexperts.com> mark-dce <mark@curationexperts.com>
+Andrew Myers <andrew_myers@wgbh.org> afred <afredmyers@gmail.com>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,8 @@ If the contributor works for an institution, the institution must have a Corpora
 
 https://wiki.duraspace.org/display/hydra/Hydra+Project+Intellectual+Property+Licensing+and+Ownership
 
+You should also add yourself to the `CONTRIBUTORS.md` file in the root of the project.
+
 ## Contribution Tasks
 
 * Reporting Issues

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,8 @@
+Contributors to this project:
+
+*  Andrew Myers
+*  Jeremy Friesen
+*  Jessie Keck
+*  Justin Coyne
+*  Mark Bussey
+

--- a/script/contributors.sh
+++ b/script/contributors.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+#
+# Auto-generate a list of contributors for a given Git repository.
+#
+# At the root of a project:
+#
+#   ./script/contributors.sh
+#
+
+echo "Contributors to this project:" > CONTRIBUTORS.md
+echo >> CONTRIBUTORS.md
+git shortlog -s | cut -c '8-200' | awk '{print "* ", $0}' >> CONTRIBUTORS.md
+echo >> CONTRIBUTORS.md


### PR DESCRIPTION
If you have cloned a repository, it is trivial to get the list of
contributors from the repo; Without a repository clone it is
non-trivial.

The CONTRIBUTORS.md file is there as a means of easily promoting and
referencing "These are the people that have contributed to the project."

The initial CONTRIBUTORS.md was created via `./script/contributors.sh`
