### PR TITLE
Adding path and banner option for changelog

### DIFF
--- a/script/changelog.sh
+++ b/script/changelog.sh
@@ -6,20 +6,24 @@ function show_help() {
   echo "  are merges or contain the following: \"$skip_tag\""
   echo
   echo "Format:"
-  echo "commit subject [committer name]"
+  echo "YYYY-MM-DD: commit subject [committer name]"
   echo
   echo "Options:"
   echo "-v                   Verbose output (i.e. include full commit messages)"
   echo "-r <since>..<until>  Range of commits to query, see \`git log\` for more"
   echo "                       defaults to most recent version tag (i.e. \"`default_range`\")"
+  echo "-b                   Add a banner to the output"
+  echo "-p                   Specify the working directory of the repository (default: \"$repository_path\")"
 }
 
 verbose=0
 range_parameter=0
+banner=0
 skip_tag="\[log skip\]"
+repository_path="./"
 
 function default_range() {
-  local latest_version_tag=`git tag | grep ^v | sort | tail -1`
+  local latest_version_tag=`cd $repository_path && git tag | grep ^v | sort | tail -1`
   # a ".." range tag causes the `git log` command to fail
   if [ -z "$latest_version_tag" ]; then
     echo ''
@@ -28,11 +32,14 @@ function default_range() {
   fi
 }
 
-while getopts "h?vr:" opt; do
+while getopts "h?bvp:r:" opt; do
   case $opt in
     h|\?)
       show_help
       exit 0
+    ;;
+    b )
+      banner=1
     ;;
     v )
       verbose=1
@@ -40,9 +47,11 @@ while getopts "h?vr:" opt; do
     r )
       range_parameter=$OPTARG
     ;;
+    p )
+      repository_path=$OPTARG
+    ;;
   esac
 done;
-
 
 function get_range() {
   if [ $range_parameter = 0 ]; then
@@ -56,7 +65,7 @@ range=`get_range`
 
 function get_format() {
   # Subject/author line wraps at 80 characters, no padding
-  local format_subject_author="%w(80,0,0)%s [%cN]%n"
+  local format_subject_author="%w(80,0,0)%ad: %s [%cN]%n"
   if [ $verbose = 0 ]; then
     echo "tformat:$format_subject_author"
   else
@@ -65,13 +74,22 @@ function get_format() {
 }
 pretty_format=`get_format`
 
-function main() {
+function changelog() {
   # Get a list of all SHA1 commits
   #   Filter the list to exclude all SHA1 commits with $skip_tag
   #   Then requery the log and output format
-  git log $range --no-merges --format=%H $@ |
-    grep -v -f <(git log $range --no-merges --format=%H "--grep=$skip_tag" $@) |
-    git log $range --no-merges --pretty="$pretty_format" --stdin --no-walk
+  cd $repository_path && git log $range --no-merges --format=%H $@ |
+    grep -v -f <(cd $repository_path && git log $range --no-merges --format=%H --grep="$skip_tag" $@) |
+    git log $range --no-merges --pretty="$pretty_format" --date=short --stdin --no-walk
+}
+
+function main() {
+  if [ $banner = 1 ]; then
+    echo $range
+    echo $range | sed -e 's/./-/g'
+    echo ''
+  fi
+  changelog
 }
 
 main


### PR DESCRIPTION
Prior to this commit, you couldn't specify the path of the repository
from which you wanted to build the changelog.
