### PR TITLE
Correcting hydra/head require

### DIFF
--- a/lib/hydra.rb
+++ b/lib/hydra.rb
@@ -1,6 +1,6 @@
 puts "REQUIRING HYDRA"
 require "hydra/version"
-require 'hydra-head'
+require 'hydra/head'
 require 'active-fedora'
 require 'rails'
 require 'om'


### PR DESCRIPTION
Following the Dive into Hydra tutorial, the `rails generate
hydra:install` command bombed. It appears that hydra-head changed
its files (for the good) so that we now need to `require 'hydra/head'`
