### PR TITLE
Don't report Gemnasium dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ This gem provides a distibution-like snapshot of all dependencies within the cor
 ## Code Status
 [![Gem Version](https://badge.fury.io/rb/hydra.png)](http://badge.fury.io/rb/hydra)
 [![Build Status](https://travis-ci.org/projecthydra/hydra-head.png?branch=master)](https://travis-ci.org/projecthydrahydra/hydra-head)
-[![Dependencies Status](https://gemnasium.com/projecthydra/hydra.png)](https://gemnasium.com/projecthydra/hydra)
 
 ## For Developers
 


### PR DESCRIPTION
Because the hydra gem is meant to be a stable snapshot of hydra gems,
it's almost always going to be behind on the most recent available
dependencies.  Showing this on the README may confuse a potential user
into believing the project is out of date.
